### PR TITLE
cpu usage halved; modified spawn column slightly

### DIFF
--- a/client/control.py
+++ b/client/control.py
@@ -40,5 +40,7 @@ class Control:
 
     def main_game_loop(self):
         while not self.done:
+            # essentially sleeps when not doing game logic so that the tick rate is consistent
+            self.clock.tick(g.tick_rate)/1000.0
             self.update()
             self.draw()

--- a/server/control.py
+++ b/server/control.py
@@ -29,5 +29,6 @@ class Control:
 
     def main_game_loop(self):
         while not self.done:
+            # essentially sleeps when not doing game logic so that the tick rate is consistent
             self.clock.tick(g.tick_rate)/1000.0
             self.update()

--- a/server/states/game.py
+++ b/server/states/game.py
@@ -85,15 +85,16 @@ class Game(State):
         self.state.players = [Player(x) for x in range(self.state.player_count)]
 
         # split the board into PLAYER_COUNT equal sections (using floats), find the middle of the section we care about
-        # using the average, and round down for the left half, and [round up for the right half for an even number of
-        # players, round down for the right half for an odd number of players]
+        # using the average, and round down for the left half, and round up for the right half
         # that way the pieces hopefully don't overlap spawn positions and things stay symmetrical
-        # somehow it seems to work this way between 1-6 players (except 5?), so hopefully that will port well into 7+
+        # somehow it seems to work this way between 1-5 players (6 has some odd stuff; I'd bet it's some number theory
+        # throwing it off, and perhaps it'll be really difficult and different stuff must be implemented),
+        # so hopefully that will port well into 7+ after it's fixed in a general way for 6 player
         # this is all based on I piece spawn position, to help make all the 4 columns 'allocated' to each player be as
         # evenly spread as possible
         if self.state.player_count > 1:
             for player in self.state.players:
-                player.spawn_column = int(((self.state.board_width / self.state.player_count) * player.player_number + (self.state.board_width / self.state.player_count) * (player.player_number + 1)) / 2) + ((self.state.player_count + 1) % 2) * player.player_number // ((self.state.player_count + 1) // 2)
+                player.spawn_column = round((((self.state.board_width - 1) / self.state.player_count) * player.player_number + (self.state.board_width / self.state.player_count) * (player.player_number + 1)) / 2) #+ ((self.state.player_count + 1) % 2) * player.player_number // ((self.state.player_count + 1) // 2)
         elif self.state.player_count == 1:
             self.state.players[0].spawn_column = self.state.board_width // 2
 

--- a/server/states/game.py
+++ b/server/states/game.py
@@ -84,9 +84,18 @@ class Game(State):
 
         self.state.players = [Player(x) for x in range(self.state.player_count)]
 
-        # split the board into PLAYER_COUNT equal sections (using floats), find the middle of the section we care about using the average, and round to nearest column
-        for player in self.state.players:
-            player.spawn_column = int(((self.state.board_width / self.state.player_count) * player.player_number + (self.state.board_width / self.state.player_count) * (player.player_number + 1)) / 2)
+        # split the board into PLAYER_COUNT equal sections (using floats), find the middle of the section we care about
+        # using the average, and round down for the left half, and [round up for the right half for an even number of
+        # players, round down for the right half for an odd number of players]
+        # that way the pieces hopefully don't overlap spawn positions and things stay symmetrical
+        # somehow it seems to work this way between 1-6 players (except 5?), so hopefully that will port well into 7+
+        # this is all based on I piece spawn position, to help make all the 4 columns 'allocated' to each player be as
+        # evenly spread as possible
+        if self.state.player_count > 1:
+            for player in self.state.players:
+                player.spawn_column = int(((self.state.board_width / self.state.player_count) * player.player_number + (self.state.board_width / self.state.player_count) * (player.player_number + 1)) / 2) + ((self.state.player_count + 1) % 2) * player.player_number // ((self.state.player_count + 1) // 2)
+        elif self.state.player_count == 1:
+            self.state.players[0].spawn_column = self.state.board_width // 2
 
     def do_event(self, event, player_number):
 


### PR DESCRIPTION
The spawn column is perfect for any player number 1-6 except 5.  
By 'perfect' I mean that in the case that every player gets an I piece or every player gets an O piece, all would be as perfectly evenly spaced as possible.  
With an odd number of players it's hard because what do you do with the middle player? Well, they should stay in the middle column, rounding to the right (rounding up). But the spacing is all weird.  
It might be best for me to rethink how this is being calculated and maybe do something with the fact that each player, in a way, has 4 spawn columns for a long piece, or perhaps there's just a better way to do it entirely by getting some sort of length and multiplying that by `(self.state.player_count + 1)` and then rounding to the nearest column. That actually might be the correct way of doing that. Will do more testing and maybe add a commit to this.